### PR TITLE
Disable -fix for now

### DIFF
--- a/structslop.go
+++ b/structslop.go
@@ -60,19 +60,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		pass.Report(analysis.Diagnostic{
-			Pos:     n.Pos(),
-			End:     n.End(),
-			Message: fmt.Sprintf("%v has size %d, could be %d, rearrange to %v for optimal size", styp, r.oldSize, r.newSize, r.suggestedStruct),
-			SuggestedFixes: []analysis.SuggestedFix{{
-				Message: fmt.Sprintf("Rearrange struct fields: %v", r.suggestedStruct),
-				TextEdits: []analysis.TextEdit{
-					{
-						Pos:     n.Pos(),
-						End:     n.End(),
-						NewText: []byte(fmt.Sprintf("%v", r.suggestedStruct)),
-					},
-				},
-			}},
+			Pos:            n.Pos(),
+			End:            n.End(),
+			Message:        fmt.Sprintf("%v has size %d, could be %d, rearrange to %v for optimal size", styp, r.oldSize, r.newSize, r.suggestedStruct),
+			SuggestedFixes: nil,
 		})
 	})
 	return nil, nil


### PR DESCRIPTION
There're two problem:

 - The comment of struct field is not preserved.
 - The type of struct field is printed in full qualified path, instead
 of legal Go syntax, e.g "struct{Jump cmd/internal/obj.As; Index int}",
 should be "struct{Jump obj.As; Index int}"

Next PR will fix the second problem, while the first is not clear can be
fixed at this time or not. To be fair, the suggested fix feature in
analysis framework is still experimental, so we should be fine.