### PR TITLE
Fix format for local type

### DIFF
--- a/testdata/src/struct/p.go
+++ b/testdata/src/struct/p.go
@@ -46,3 +46,9 @@ type s5 struct { // want `struct{.+} has size 24, could be 20, rearrange to stru
 	y uint64
 	z *httptest.Server
 }
+
+type s6 struct { // want `struct{.+} has size 24, could be 20, rearrange to struct{y uint64; z \*s; x uint32} for optimal size`
+	x uint32
+	y uint64
+	z *s
+}


### PR DESCRIPTION
PR #14 added format struct using qualified package name. But it does not
consider the case where type is local type. Example:

	pacakge p

	type s struct {}
	type t struct {
		x *s
	}

"t" will be printed as "struct { *p.s }".

Updates #13