### PR TITLE
Fix wrong size/alignment for struct

### DIFF
--- a/sizes.go
+++ b/sizes.go
@@ -1,0 +1,105 @@
+// Copyright 2020 Orijtech, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package structslop
+
+import (
+	"go/types"
+)
+
+type sizes struct {
+	stdSizes types.Sizes
+	maxAlign int64
+}
+
+func (s *sizes) Offsetsof(fields []*types.Var) []int64 {
+	offsets := make([]int64, len(fields))
+	var o int64
+	for i, f := range fields {
+		a := s.Alignof(f.Type())
+		o = align(o, a)
+		offsets[i] = o
+		o += s.Sizeof(f.Type())
+	}
+	return offsets
+}
+
+func (s *sizes) Sizeof(T types.Type) int64 {
+	switch t := T.Underlying().(type) {
+	case *types.Array:
+		return t.Len() * s.Sizeof(t.Elem())
+	case *types.Struct:
+		nf := t.NumFields()
+		if nf == 0 {
+			return 0
+		}
+		o := int64(0)
+		max := int64(1)
+		for i := 0; i < nf; i++ {
+			ft := t.Field(i).Type()
+			a, sz := s.Alignof(ft), s.Sizeof(ft)
+			if a > max {
+				max = a
+			}
+			if i == nf-1 && sz == 0 && o != 0 {
+				sz = 1
+			}
+			o = align(o, a) + sz
+		}
+		return align(o, max)
+	}
+	return s.stdSizes.Sizeof(T)
+}
+
+func (s *sizes) Alignof(T types.Type) int64 {
+	switch t := T.Underlying().(type) {
+	case *types.Array:
+		return s.Alignof(t.Elem())
+	case *types.Struct:
+		max := int64(1)
+		for i, nf := 0, t.NumFields(); i < nf; i++ {
+			if a := s.Alignof(t.Field(i).Type()); a > max {
+				max = a
+			}
+		}
+		return max
+	case *types.Slice, *types.Interface, *types.Basic:
+		return s.stdSizes.Alignof(T)
+	}
+
+	// All other types.
+	a := s.Sizeof(T)
+	if a < 1 {
+		return 1
+	}
+	// complex{64,128} are aligned like [2]float{32,64}.
+	if isComplex(T) {
+		a /= 2
+	}
+	if a > s.maxAlign {
+		return s.maxAlign
+	}
+	return a
+}
+
+// align returns the smallest x >= subject such that x % target == 0.
+func align(subject, target int64) int64 {
+	x := subject + target - 1
+	return x - x%target
+}
+
+func isComplex(typ types.Type) bool {
+	t, ok := typ.Underlying().(*types.Basic)
+	return ok && t.Info()&types.IsComplex != 0
+}

--- a/testdata/src/struct/p.go
+++ b/testdata/src/struct/p.go
@@ -27,13 +27,13 @@ type s2 struct {
 	j int
 }
 
-type s3 struct { // want "struct{.+} has size 20, could be 16, rearrange to struct{y uint64; x uint32; z uint32} for optimal size"
+type s3 struct { // want "struct{.+} has size 24, could be 16, rearrange to struct{y uint64; x uint32; z uint32} for optimal size"
 	x uint32
 	y uint64
 	z uint32
 }
 
-type s4 struct { // want `struct{.+} has size 32, could be 20, rearrange to struct{_ \[0\]func\(\); i1 int; i2 int; a3 \[3\]bool; b bool} for optimal size`
+type s4 struct { // want `struct{.+} has size 40, could be 24, rearrange to struct{_ \[0\]func\(\); i1 int; i2 int; a3 \[3\]bool; b bool} for optimal size`
 	b  bool
 	i1 int
 	i2 int
@@ -41,14 +41,22 @@ type s4 struct { // want `struct{.+} has size 32, could be 20, rearrange to stru
 	_  [0]func()
 }
 
-type s5 struct { // want `struct{.+} has size 24, could be 20, rearrange to struct{y uint64; z \*httptest.Server; x uint32} for optimal size`
+type s5 struct { // want `struct{.+} has size 32, could be 24, rearrange to struct{y uint64; z \*httptest.Server; x uint32; t uint32} for optimal size`
 	x uint32
 	y uint64
 	z *httptest.Server
+	t uint32
 }
 
-type s6 struct { // want `struct{.+} has size 24, could be 20, rearrange to struct{y uint64; z \*s; x uint32} for optimal size`
+type s6 struct { // want `struct{.+} has size 32, could be 24, rearrange to struct{y uint64; z \*s; x uint32; t uint32} for optimal size`
 	x uint32
 	y uint64
 	z *s
+	t uint32
+}
+
+type s7 struct { // should be good, see #16
+	bytep *uint8
+	mask  uint8
+	index uintptr
 }


### PR DESCRIPTION
Currently, we use go/types.SizeFor to calculate size/alignment.
Unfortunately, go/types chose the most efficient layout model, so it
will ignore padding for last field of struct.

To fix this, we have to implement our own types.Sizes, then plug it in
to analysis pass.

See https://github.com/golang/go/issues/14909#issuecomment-199936232

Fixes #16