### PR TITLE
Running CI with go tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - 1.14.x
   - 1.15.x
+  - tip
 
 before_install:
   - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0


### PR DESCRIPTION
Since when we use "go:linkname", we should always run CI with tip to see
if it's broken or not.

Updates #22