### PR TITLE
Ignore test files by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ go:
   - 1.15.x
   - tip
 
+if: type != push OR branch = master
+
 before_install:
   - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0
 
 script:
-  - golangci-lint run
-  - go test -v
+  - ./ci/run
+

--- a/ci/run
+++ b/ci/run
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Only check build success or not on gotip
+if [ "$TRAVIS_GO_VERSION" = "tip" ]; then
+  go build ./cmd/structslop
+  exit 0
+fi
+
+golangci-lint run
+go test -v

--- a/testdata/src/include-test-files/p.go
+++ b/testdata/src/include-test-files/p.go
@@ -12,23 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package structslop_test
+package p
 
-import (
-	"testing"
-
-	"golang.org/x/tools/go/analysis/analysistest"
-
-	"github.com/orijtech/structslop"
-)
-
-func Test(t *testing.T) {
-	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, structslop.Analyzer, "struct")
-}
-
-func TestIncludeTestFiles(t *testing.T) {
-	testdata := analysistest.TestData()
-	_ = structslop.Analyzer.Flags.Set("include-test-files", "true")
-	analysistest.Run(t, testdata, structslop.Analyzer, "include-test-files")
+type s struct { // want `struct has size 24 \(size class 32\), could be 16 \(size class 16\), rearrange to struct{y uint64; x uint32; z uint32} for optimal size \(50.00% savings\)`
+	x uint32
+	y uint64
+	z uint32
 }

--- a/testdata/src/struct/p_test.go
+++ b/testdata/src/struct/p_test.go
@@ -12,23 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package structslop_test
+package p
 
-import (
-	"testing"
-
-	"golang.org/x/tools/go/analysis/analysistest"
-
-	"github.com/orijtech/structslop"
-)
-
-func Test(t *testing.T) {
-	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, structslop.Analyzer, "struct")
-}
-
-func TestIncludeTestFiles(t *testing.T) {
-	testdata := analysistest.TestData()
-	_ = structslop.Analyzer.Flags.Set("include-test-files", "true")
-	analysistest.Run(t, testdata, structslop.Analyzer, "include-test-files")
+// This struct is sloppy, but no report here. Test files are ignored by default.
+type ignore struct {
+	x uint32
+	y uint64
+	z uint32
 }


### PR DESCRIPTION
To include test files in check, user can use flags -include-test-files.

Fixes #29