### PR TITLE
Add verbose mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ type s2 struct {
 ```
 
 have the same size class `32`, though `s2` layout is only `24` byte in size.
+
+However, you can still get this information when you want, using `-verbose` flag:
+
+```sh
+$ structslop -verbose ./testdata/src/verbose/p.go
+/go/src/github.com/orijtech/structslop/testdata/src/verbose/p.go:17:8: struct has size 0 (size class 0)
+/go/src/github.com/orijtech/structslop/testdata/src/verbose/p.go:19:9: struct has size 1 (size class 8)
+/go/src/github.com/orijtech/structslop/testdata/src/verbose/p.go:23:9: struct has size 32 (size class 32), could be 24 (size class 32), rearrange to struct{y uint64; z *s; x uint32; t uint32} for optimal size
+```
  
 ## Development
 

--- a/structslop_test.go
+++ b/structslop_test.go
@@ -32,3 +32,9 @@ func TestIncludeTestFiles(t *testing.T) {
 	_ = structslop.Analyzer.Flags.Set("include-test-files", "true")
 	analysistest.Run(t, testdata, structslop.Analyzer, "include-test-files")
 }
+
+func TestVerboseMode(t *testing.T) {
+	testdata := analysistest.TestData()
+	_ = structslop.Analyzer.Flags.Set("verbose", "true")
+	analysistest.Run(t, testdata, structslop.Analyzer, "verbose")
+}

--- a/testdata/src/verbose/p.go
+++ b/testdata/src/verbose/p.go
@@ -1,0 +1,28 @@
+// Copyright 2020 Orijtech, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p
+
+type s struct{} // want `struct has size 0 \(size class 0\)`
+
+type s1 struct { // want `struct has size 1 \(size class 8\)`
+	b bool
+}
+
+type s3 struct { // want `struct has size 32 \(size class 32\), could be 24 \(size class 32\), rearrange to struct{y uint64; z \*s; x uint32; t uint32} for optimal size`
+	x uint32
+	y uint64
+	z *s
+	t uint32
+}


### PR DESCRIPTION
So structslop will print all details information about the struct, even
when it is not sloppy. This includes struct size, size class, and the GC
size change even when size class is still the same.

Fixes #32