### PR TITLE
Fix invalid *ast.Struct construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Without Go modules:
 
 ```sh
 $ cd $GOPATH/src/github.com/orijtech/structslop
-$ git checkout v0.0.4
+$ git checkout v0.0.5
 $ go get
 $ install ./cmd/structslop
 ```

--- a/testdata/src/struct/p.go
+++ b/testdata/src/struct/p.go
@@ -71,3 +71,11 @@ type s8 struct { // want `struct has size 40 \(size class 48\), could be 32 \(si
 	z uint32
 	w uint64
 }
+
+// Struct which combines multiple fields of the same type, see issue #41.
+type s9 struct { // want `struct has size 40 \(size class 48\), could be 24 \(size class 32\), you'll save 33.33% if you rearrange it to:\nstruct {\n\t_  \[0\]func\(\)\n\ti1 int\n\ti2 int\n\ta3 \[3\]bool\n\tb  bool\n}`
+	b      bool
+	i1, i2 int
+	a3     [3]bool
+	_      [0]func()
+}


### PR DESCRIPTION
Currently, we compose new *ast.StructType for pretty print optimal
struct. But *ast.StructType can compose multiple fields of the same type
into one element of *ast.StructType.Fields, causing mismatch with the
optimal indexes.

To fix this, we format new optimal struct as before, then parsing the
returned string to compose new *ast.StructType instead.

Fixes #41