### PR TITLE
.github: bump go version to 1.16.x

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+
 jobs:
   test:
     name: Test
@@ -13,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16.x
       - run: go version
       - run: go test -race -v ./...
   build-gotip:
@@ -23,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16.x
       - run: go get golang.org/dl/gotip
       - run: gotip download
       - run: gotip version

--- a/testdata/src/include-test-files/p.go
+++ b/testdata/src/include-test-files/p.go
@@ -14,7 +14,7 @@
 
 package p
 
-type s struct { // want `struct has size 24 \(size class 32\), could be 16 \(size class 16\), you'll save 50.00% if you rearrange it to:\nstruct {\n\ty uint64\n\tx uint32\n\tz uint32\n}`
+type s struct { // want `struct has size 24 \(size class 24\), could be 16 \(size class 16\), you'll save 33.33% if you rearrange it to:\nstruct {\n\ty uint64\n\tx uint32\n\tz uint32\n}`
 	x uint32
 	y uint64
 	z uint32

--- a/testdata/src/struct/p.go
+++ b/testdata/src/struct/p.go
@@ -27,13 +27,13 @@ type s2 struct {
 	j int
 }
 
-type s3 struct { // want `struct has size 24 \(size class 32\), could be 16 \(size class 16\), you'll save 50.00% if you rearrange it to:\nstruct {\n\ty uint64\n\tx uint32\n\tz uint32\n}`
+type s3 struct { // want `struct has size 24 \(size class 24\), could be 16 \(size class 16\), you'll save 33.33% if you rearrange it to:\nstruct {\n\ty uint64\n\tx uint32\n\tz uint32\n}`
 	x uint32
 	y uint64
 	z uint32
 }
 
-type s4 struct { // want `struct has size 40 \(size class 48\), could be 24 \(size class 32\), you'll save 33.33% if you rearrange it to:\nstruct {\n\t_  \[0\]func\(\)\n\ti1 int\n\ti2 int\n\ta3 \[3\]bool\n\tb  bool\n}`
+type s4 struct { // want `struct has size 40 \(size class 48\), could be 24 \(size class 24\), you'll save 50.00% if you rearrange it to:\nstruct {\n\t_  \[0\]func\(\)\n\ti1 int\n\ti2 int\n\ta3 \[3\]bool\n\tb  bool\n}`
 	b  bool
 	i1 int
 	i2 int
@@ -43,7 +43,7 @@ type s4 struct { // want `struct has size 40 \(size class 48\), could be 24 \(si
 
 // should be good, the struct has size 32, can be rearrange to have size 24, but runtime allocator
 // allocate the same size class 32.
-type s5 struct {
+type s5 struct { // want `struct has size 32 \(size class 32\), could be 24 \(size class 24\), you'll save 25.00% if you rearrange it to:\nstruct {\n\ty uint64\n\tz \*s\n\tx uint32\n\tt uint32\n}`
 	x uint32
 	y uint64
 	z *s
@@ -73,7 +73,7 @@ type s8 struct { // want `struct has size 40 \(size class 48\), could be 32 \(si
 }
 
 // Struct which combines multiple fields of the same type, see issue #41.
-type s9 struct { // want `struct has size 40 \(size class 48\), could be 24 \(size class 32\), you'll save 33.33% if you rearrange it to:\nstruct {\n\t_  \[0\]func\(\)\n\ti1 int\n\ti2 int\n\ta3 \[3\]bool\n\tb  bool\n}`
+type s9 struct { // want `struct has size 40 \(size class 48\), could be 24 \(size class 24\), you'll save 50.00% if you rearrange it to:\nstruct {\n\t_  \[0\]func\(\)\n\ti1 int\n\ti2 int\n\ta3 \[3\]bool\n\tb  bool\n}`
 	b      bool
 	i1, i2 int
 	a3     [3]bool
@@ -81,7 +81,7 @@ type s9 struct { // want `struct has size 40 \(size class 48\), could be 24 \(si
 }
 
 // Preserve comments.
-type s10 struct { // want `struct has size 40 \(size class 48\), could be 24 \(size class 32\), you'll save 33.33% if you rearrange it to:\nstruct {\n\t_  \[0\]func\(\)\n\ti1 int\n\ti2 int\n\ta3 \[3\]bool\n\tb  bool\n}`
+type s10 struct { // want `struct has size 40 \(size class 48\), could be 24 \(size class 24\), you'll save 50.00% if you rearrange it to:\nstruct {\n\t_  \[0\]func\(\)\n\ti1 int\n\ti2 int\n\ta3 \[3\]bool\n\tb  bool\n}`
 	b      bool    // b is bool
 	i1, i2 int     // i1, i2 are int
 	a3     [3]bool // a3 is array of bool

--- a/testdata/src/struct/p.go.golden
+++ b/testdata/src/struct/p.go.golden
@@ -27,13 +27,13 @@ type s2 struct {
 	j int
 }
 
-type s3 struct { // want `struct has size 24 \(size class 32\), could be 16 \(size class 16\), you'll save 50.00% if you rearrange it to:\nstruct {\n\ty uint64\n\tx uint32\n\tz uint32\n}`
+type s3 struct { // want `struct has size 24 \(size class 24\), could be 16 \(size class 16\), you'll save 33.33% if you rearrange it to:\nstruct {\n\ty uint64\n\tx uint32\n\tz uint32\n}`
 	y uint64
 	x uint32
 	z uint32
 }
 
-type s4 struct { // want `struct has size 40 \(size class 48\), could be 24 \(size class 32\), you'll save 33.33% if you rearrange it to:\nstruct {\n\t_  \[0\]func\(\)\n\ti1 int\n\ti2 int\n\ta3 \[3\]bool\n\tb  bool\n}`
+type s4 struct { // want `struct has size 40 \(size class 48\), could be 24 \(size class 24\), you'll save 50.00% if you rearrange it to:\nstruct {\n\t_  \[0\]func\(\)\n\ti1 int\n\ti2 int\n\ta3 \[3\]bool\n\tb  bool\n}`
 	_  [0]func()
 	i1 int
 	i2 int
@@ -43,10 +43,10 @@ type s4 struct { // want `struct has size 40 \(size class 48\), could be 24 \(si
 
 // should be good, the struct has size 32, can be rearrange to have size 24, but runtime allocator
 // allocate the same size class 32.
-type s5 struct {
-	x uint32
+type s5 struct { // want `struct has size 32 \(size class 32\), could be 24 \(size class 24\), you'll save 25.00% if you rearrange it to:\nstruct {\n\ty uint64\n\tz \*s\n\tx uint32\n\tt uint32\n}`
 	y uint64
 	z *s
+	x uint32
 	t uint32
 }
 
@@ -73,7 +73,7 @@ type s8 struct { // want `struct has size 40 \(size class 48\), could be 32 \(si
 }
 
 // Struct which combines multiple fields of the same type, see issue #41.
-type s9 struct { // want `struct has size 40 \(size class 48\), could be 24 \(size class 32\), you'll save 33.33% if you rearrange it to:\nstruct {\n\t_  \[0\]func\(\)\n\ti1 int\n\ti2 int\n\ta3 \[3\]bool\n\tb  bool\n}`
+type s9 struct { // want `struct has size 40 \(size class 48\), could be 24 \(size class 24\), you'll save 50.00% if you rearrange it to:\nstruct {\n\t_  \[0\]func\(\)\n\ti1 int\n\ti2 int\n\ta3 \[3\]bool\n\tb  bool\n}`
 	_      [0]func()
 	i1, i2 int
 	a3     [3]bool
@@ -81,7 +81,7 @@ type s9 struct { // want `struct has size 40 \(size class 48\), could be 24 \(si
 }
 
 // Preserve comments.
-type s10 struct { // want `struct has size 40 \(size class 48\), could be 24 \(size class 32\), you'll save 33.33% if you rearrange it to:\nstruct {\n\t_  \[0\]func\(\)\n\ti1 int\n\ti2 int\n\ta3 \[3\]bool\n\tb  bool\n}`
+type s10 struct { // want `struct has size 40 \(size class 48\), could be 24 \(size class 24\), you'll save 50.00% if you rearrange it to:\nstruct {\n\t_  \[0\]func\(\)\n\ti1 int\n\ti2 int\n\ta3 \[3\]bool\n\tb  bool\n}`
 	_      [0]func()
 	i1, i2 int     // i1, i2 are int
 	a3     [3]bool // a3 is array of bool

--- a/testdata/src/verbose/p.go
+++ b/testdata/src/verbose/p.go
@@ -20,7 +20,7 @@ type s1 struct { // want `struct has size 1 \(size class 8\)`
 	b bool
 }
 
-type s3 struct { // want `struct has size 32 \(size class 32\), could be 24 \(size class 32\), optimal fields order:\nstruct {\n\ty uint64\n\tz \*s\n\tx uint32\n\tt uint32\n}`
+type s3 struct { // want `struct has size 32 \(size class 32\), could be 24 \(size class 24\), you'll save 25.00% if you rearrange it to:\nstruct {\n\ty uint64\n\tz \*s\n\tx uint32\n\tt uint32\n}`
 	x uint32
 	y uint64
 	z *s


### PR DESCRIPTION
Since when go1.17 will be released next Monday, thus it's EOL for go1.15