### PR TITLE
Include bytes saved in the output

### DIFF
--- a/structslop.go
+++ b/structslop.go
@@ -125,11 +125,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			)
 			if r.sloppy() {
 				msg = fmt.Sprintf(
-					"struct has size %d (size class %d), could be %d (size class %d), you'll save %.2f%% if you rearrange it to:\n%s\n",
+					"struct has size %d (size class %d), could be %d (size class %d), you'll save %.2f%% (%d bytes) if you rearrange it to:\n%s\n",
 					r.oldGcSize,
 					r.oldRuntimeSize,
 					r.newGcSize,
 					r.newRuntimeSize,
+					r.savingsPercent(),
 					r.savings(),
 					buf.String(),
 				)
@@ -207,8 +208,12 @@ func (r result) sloppy() bool {
 	return r.oldRuntimeSize > r.newRuntimeSize
 }
 
-func (r result) savings() float64 {
-	return float64(r.oldRuntimeSize-r.newRuntimeSize) / float64(r.oldRuntimeSize) * 100
+func (r result) savingsPercent() float64 {
+	return float64(r.savings()) / float64(r.oldRuntimeSize) * 100
+}
+
+func (r result) savings() int64 {
+	return r.oldRuntimeSize - r.newRuntimeSize
 }
 
 func mapFieldIdx(s *types.Struct) map[*types.Var]int {


### PR DESCRIPTION
Sometimes, the number of bytes saved is more important to know than a percentage like "15%".

In this PR, I change the output to include the number of bytes saved so that it looks like this:

`struct has size 200 (size class 208), could be 192 (size class 192), you'll save 7.69% (16 bytes) if you rearrange it to:`
