### PR TITLE
update README ( how to install in the newer golang versions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Package structslop defines an [Analyzer](analyzer_link) that checks if struct fi
 With Go modules:
 
 ```sh
-go get github.com/orijtech/structslop/cmd/structslop
+go install github.com/orijtech/structslop/cmd/structslop@latest
 ```
 
 Without Go modules:


### PR DESCRIPTION
Hey, 

in Go version +1.18,  using install is a better way to install it.  :) 
just a small update on README file is here 

Cheers, 